### PR TITLE
📝 Docs: Add documentation to pkg/remote

### DIFF
--- a/pkg/remote/provider.go
+++ b/pkg/remote/provider.go
@@ -6,13 +6,23 @@ import (
 	"github.com/lucasew/mclone/pkg/message"
 )
 
+// Model represents a language model available from a provider.
 type Model struct {
-	Name string // display name
-	Slug string // identifier for --model
+	Name string // Display name shown to users
+	Slug string // Unique identifier used in CLI arguments (e.g. --model)
 }
 
+// Provider defines the interface for interacting with LLM backends.
+// Implementations handle the specifics of communicating with services like OpenAI, Anthropic, or Ollama.
 type Provider interface {
+	// Name returns the unique identifier of the provider instance.
 	Name() string
+
+	// List returns the available models for this provider.
 	List(ctx context.Context) ([]Model, error)
+
+	// Chat initiates a conversation with the specified model.
+	// It returns a channel that streams ChatResponse chunks as they are generated.
+	// The channel is closed when the response is complete.
 	Chat(ctx context.Context, modelName string, messages []message.Message, options message.ChatOptions) (<-chan message.ChatResponse, error)
 }

--- a/pkg/remote/registry.go
+++ b/pkg/remote/registry.go
@@ -10,21 +10,34 @@ import (
 	"github.com/mitchellh/mapstructure"
 )
 
+// Factory is a function type for creating new Provider instances.
+// It receives the name of the remote, its configuration options, and a Resolver for looking up other remotes.
 type Factory func(name string, options map[string]any, resolve Resolver) (Provider, error)
 
-// Resolver provides access to both provider and searcher resolution.
+// Resolver acts as a central registry for looking up providers and searchers.
+// It abstracts away the details of configuration and instantiation.
 type Resolver struct {
-	Provider      func(remoteName string) (Provider, error)
-	Searcher      func(remoteName string) (Searcher, error)
+	// Provider resolves a remote name to a Provider instance.
+	// It handles caching and implicit balance group resolution.
+	Provider func(remoteName string) (Provider, error)
+
+	// Searcher resolves a remote name to a Searcher instance.
+	Searcher func(remoteName string) (Searcher, error)
+
+	// UpdateOptions updates the configuration options for a given remote.
+	// This persists the changes to the configuration file.
 	UpdateOptions func(remoteName string, options map[string]any) error
 }
 
 var registry = make(map[string]Factory)
 
+// Register adds a new provider type to the registry.
+// The typeName is used in the configuration file to specify the provider type (e.g., "openai", "anthropic").
 func Register(typeName string, factory Factory) {
 	registry[typeName] = factory
 }
 
+// ListTypes returns a slice of all registered provider type names.
 func ListTypes() []string {
 	var types []string
 	for t := range registry {
@@ -33,9 +46,20 @@ func ListTypes() []string {
 	return types
 }
 
-// NewResolver creates a Resolver from a config.
-// It supports implicit balance groups via the ":" naming convention:
-// remotes named "anth:1", "anth:2" form an implicit balance group "anth".
+// NewResolver creates a new Resolver instance based on the provided configuration.
+//
+// Implicit Balancing:
+// NewResolver implements an implicit balancing mechanism. If a remote name is not explicitly defined
+// with a type, the resolver looks for remotes that share the name as a prefix followed by a colon (e.g., "myremote:1", "myremote:2").
+// If found, these remotes are automatically grouped into a balanced pool under the "myremote" name.
+//
+// Failover Configuration:
+// When an implicit balance group is created, it inherits options from the base remote configuration if it exists.
+// Additionally, it aggregates `failover_threshold` settings from individual members, allowing specific failover policies per backend.
+//
+// Configuration Updates:
+// The returned Resolver includes an UpdateOptions function that writes changes back to the configuration file,
+// ensuring persistence of runtime changes like disabling a failing backend.
 func NewResolver(conf *config.Config) Resolver {
 	providerCache := make(map[string]Provider)
 	searcherCache := make(map[string]Searcher)
@@ -105,6 +129,13 @@ func NewResolver(conf *config.Config) Resolver {
 	return resolve
 }
 
+// resolveOne attempts to resolve a single provider or construct a balance group.
+//
+// It follows this logic:
+// 1. Checks for an exact match in the config with a defined Type.
+// 2. If no exact match with Type, looks for "implicit members" (remotes starting with "remoteName:").
+// 3. If members are found, constructs a "balance" provider grouping them.
+// 4. Propagates `failover_threshold` from members to the group options.
 func resolveOne(conf *config.Config, remoteName string, resolve Resolver) (Provider, error) {
 	rc, exactMatch := conf.Remotes[remoteName]
 
@@ -166,6 +197,8 @@ func resolveOne(conf *config.Config, remoteName string, resolve Resolver) (Provi
 	return factory(remoteName, opts, resolve)
 }
 
+// NewProvider creates a new provider instance directly by type name.
+// This bypasses the Resolver logic and is useful for direct instantiation or testing.
 func NewProvider(typeName string, name string, options map[string]any) (Provider, error) {
 	factory, ok := registry[typeName]
 	if !ok {
@@ -174,7 +207,11 @@ func NewProvider(typeName string, name string, options map[string]any) (Provider
 	return factory(name, options, Resolver{})
 }
 
-// DecodeOptions decodes input into output using mapstructure with weak typing.
+// DecodeOptions maps a generic map[string]any configuration to a specific struct.
+//
+// It uses `mapstructure` with `WeaklyTypedInput: true`, enabling loose type conversion
+// (e.g., parsing string "123" into an int field). This is critical for parsing TOML/env configurations
+// where types might not strict matches.
 func DecodeOptions(input interface{}, output interface{}) error {
 	config := &mapstructure.DecoderConfig{
 		Metadata:         nil,

--- a/pkg/remote/search.go
+++ b/pkg/remote/search.go
@@ -5,29 +5,36 @@ import (
 	"fmt"
 )
 
-// SearchResult represents a single search result.
+// SearchResult represents a single item returned from a search query.
+// It normalizes results from different search providers (e.g. Google, Bing) into a common format.
 type SearchResult struct {
-	Title   string
-	URL     string
-	Snippet string
+	Title   string // The title of the search result page
+	URL     string // The direct link to the result
+	Snippet string // A brief text snippet or summary of the content
 }
 
-// Searcher can execute web searches.
+// Searcher is the interface for executing web searches.
+// Implementations wrap specific search engine APIs.
 type Searcher interface {
+	// Search executes a query and returns up to maxResults items.
+	// It should return an error if the backend is unreachable or the query fails.
 	Search(ctx context.Context, query string, maxResults int) ([]SearchResult, error)
 }
 
-// SearchFactory creates a Searcher from config options.
+// SearchFactory is a function type for creating new Searcher instances.
+// It receives the name of the search remote and its configuration options.
 type SearchFactory func(name string, options map[string]any) (Searcher, error)
 
 var searchRegistry = make(map[string]SearchFactory)
 
-// RegisterSearcher registers a search backend type.
+// RegisterSearcher registers a search backend type (e.g., "google", "ddg").
+// The typeName matches the "type" field in the configuration.
 func RegisterSearcher(typeName string, factory SearchFactory) {
 	searchRegistry[typeName] = factory
 }
 
-// NewSearcher creates a Searcher by type name.
+// NewSearcher creates a new Searcher instance by its type name.
+// It looks up the factory in the registry and instantiates the searcher.
 func NewSearcher(typeName, name string, options map[string]any) (Searcher, error) {
 	factory, ok := searchRegistry[typeName]
 	if !ok {


### PR DESCRIPTION
I have added comprehensive documentation to the `pkg/remote` package, focusing on:

1.  **Implicit Balancing:** Documented the `NewResolver` function to explain how remotes with shared prefixes (e.g., `remote:1`, `remote:2`) are automatically grouped into a balanced pool.
2.  **Failover Logic:** Explained how `failover_threshold` settings are inherited from member remotes.
3.  **Core Interfaces:** Added docstrings to `Provider`, `Searcher`, and their associated structs (`Model`, `SearchResult`).
4.  **Configuration:** Documented `DecodeOptions` to clarify the use of `WeaklyTypedInput: true` for flexible configuration parsing.

This documentation aims to help new contributors and users understand the non-obvious behaviors of the provider resolution system.


---
*PR created automatically by Jules for task [17597166884852746321](https://jules.google.com/task/17597166884852746321) started by @lucasew*