### PR TITLE
🛟 Arrumador: Configure tooling and CI

### DIFF
--- a/.github/workflows/autorelease.yml
+++ b/.github/workflows/autorelease.yml
@@ -17,6 +17,8 @@ jobs:
       pull-requests: write
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.head_ref || github.ref_name }}
 
       - name: Setup mise
         uses: jdx/mise-action@v3

--- a/.github/workflows/autorelease.yml
+++ b/.github/workflows/autorelease.yml
@@ -1,0 +1,55 @@
+name: "autorelease"
+
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - '*'
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  mise-ci:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup mise
+        uses: jdx/mise-action@v3
+
+      - name: Install dependencies
+        run: mise run install
+
+      - name: Run codegen
+        run: mise run codegen
+
+      - name: Create Pull Request if code changed
+        uses: peter-evans/create-pull-request@v6
+        with:
+          commit-message: "chore: update generated code"
+          title: "chore: update generated code"
+          branch: "chore/update-codegen"
+
+      - name: Run CI
+        run: mise run ci
+
+      - name: Build binary for release
+        if: github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/')
+        run: mise run build
+
+      - name: Release (Conditional)
+        if: github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/')
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh release create ${{ github.ref_name }} --generate-notes
+
+      - name: Upload Artifacts (Conditional)
+        if: github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/')
+        uses: actions/upload-artifact@v4
+        with:
+          name: mclone-binary
+          path: mclone

--- a/.github/workflows/autorelease.yml
+++ b/.github/workflows/autorelease.yml
@@ -3,7 +3,7 @@ name: "autorelease"
 on:
   push:
     branches:
-      - main
+      - "**"
     tags:
       - '*'
   pull_request:

--- a/mise.toml
+++ b/mise.toml
@@ -7,18 +7,29 @@ svu = "3.3.0"
 
 [tasks.install]
 description = "Install dependencies"
-run = "go mod download"
+depends = ["install:*"]
+run = """
+#!/usr/bin/env bash
+if [ -f "go.mod" ]; then
+  go mod download
+elif [ -f "package.json" ]; then
+  npm install
+fi
+"""
 
 [tasks.codegen]
 description = "Update generated code"
+depends = ["codegen:*"]
 run = "go generate ./..."
 
 [tasks.test]
 description = "Run tests"
+depends = ["test:*"]
 run = "go test -v ./..."
 
 [tasks.build]
 description = "Build the binary"
+depends = ["build:*"]
 run = "go build -o mclone ./cmd/mclone"
 
 [tasks.lint]
@@ -31,7 +42,7 @@ run = "workspaced codebase format"
 
 [tasks.ci]
 description = "Run CI pipeline"
-depends = ["lint", "test", "build"]
+depends = ["lint", "test"]
 
 [tasks.release]
 description = "Run a release"

--- a/mise.toml
+++ b/mise.toml
@@ -8,6 +8,9 @@ svu = "3.3.0"
 [tasks.install]
 description = "Install dependencies"
 depends = ["install:*"]
+
+[tasks."install:deps"]
+description = "Smartly detect the package manager and install dependencies"
 run = """
 #!/usr/bin/env bash
 if [ -f "go.mod" ]; then
@@ -20,16 +23,22 @@ fi
 [tasks.codegen]
 description = "Update generated code"
 depends = ["codegen:*"]
+
+[tasks."codegen:main"]
 run = "go generate ./..."
 
 [tasks.test]
 description = "Run tests"
 depends = ["test:*"]
+
+[tasks."test:main"]
 run = "go test -v ./..."
 
 [tasks.build]
 description = "Build the binary"
 depends = ["build:*"]
+
+[tasks."build:main"]
 run = "go build -o mclone ./cmd/mclone"
 
 [tasks.lint]


### PR DESCRIPTION
## Assumptions
- The project is not hosted on Vercel or Cloudflare Workers because there is no `vercel.json` or `wrangler.toml` file, so the conditional release and artifact steps were explicitly added.
- The `[task]:*` dependency rule was interpreted as adding `depends = ["install:*"]`, etc., to allow wildcard evaluation properly in `mise`.
- Since `build` was explicitly removed from `ci` dependencies to strictly follow the prompt (`ci` depends ONLY on `["lint", "test"]`), a separate `mise run build` step was added to the workflow right before the release to ensure the `mclone` binary is actually built and available for artifact upload.

## Alternatives Not Chosen
- Skipping the artifact step completely (chosen to add the build step to make the artifact upload actually work, ensuring a robust pipeline).
- Running tests as part of the `build` task (chosen to separate concerns as requested).

## How To Pivot
- If you don't want the binary uploaded as an artifact, you can remove the `Build binary for release` and `Upload Artifacts (Conditional)` steps from `.github/workflows/autorelease.yml`.

## Next Knobs
- `mise.toml`: `tasks.ci` - You can add `build` back to the `depends` array if you want the `mise run ci` task to also build the binary.
- `.github/workflows/autorelease.yml`: `peter-evans/create-pull-request@v6` step - You can modify the `branch` or `commit-message` configurations to match any specific convention you need.

---
*PR created automatically by Jules for task [6983343820028231082](https://jules.google.com/task/6983343820028231082) started by @lucasew*