### PR TITLE
📝 Docs: Add comprehensive docstrings for remote provider and registry

### DIFF
--- a/pkg/remote/provider.go
+++ b/pkg/remote/provider.go
@@ -6,13 +6,26 @@ import (
 	"github.com/lucasew/mclone/pkg/message"
 )
 
+// Model represents an AI model offered by a provider.
+// It maps the provider's internal identifier (Slug) to a human-readable name.
 type Model struct {
 	Name string // display name
 	Slug string // identifier for --model
 }
 
+// Provider defines the contract for an AI backend (e.g., OpenAI, Anthropic, local).
+// Providers are responsible for listing their available models and handling
+// chat completions. They are registered dynamically and resolved via the remote registry.
 type Provider interface {
+	// Name returns the provider's display name or type identifier.
 	Name() string
+
+	// List queries the backend for its currently available models.
+	// This may involve network requests or authentication checks.
 	List(ctx context.Context) ([]Model, error)
+
+	// Chat streams a conversation completion from the backend.
+	// It returns a channel that yields response chunks and an error if the request fails.
+	// The caller is responsible for consuming the channel until it's closed.
 	Chat(ctx context.Context, modelName string, messages []message.Message, options message.ChatOptions) (<-chan message.ChatResponse, error)
 }

--- a/pkg/remote/registry.go
+++ b/pkg/remote/registry.go
@@ -11,21 +11,36 @@ import (
 	"github.com/mitchellh/mapstructure"
 )
 
+// Factory describes a constructor for creating an instance of a Provider.
+// It receives a unique remote name, its configuration options from the mclone.conf,
+// and a Resolver that can be used to construct nested or dependent components.
 type Factory func(name string, options map[string]any, resolve Resolver) (Provider, error)
 
 // Resolver provides access to provider and tool source resolution.
+// It acts as a dependency injector, allowing remotes like 'route' or 'search' to look up
+// other providers at runtime without maintaining direct references or circular dependencies.
 type Resolver struct {
+	// Provider fetches a fully-constructed Provider instance by its remote name.
 	Provider      func(remoteName string) (Provider, error)
+
+	// ToolSource fetches a configured tools.ToolSource by its name.
 	ToolSource    func(toolName string) (tools.ToolSource, error)
+
+	// UpdateOptions persists configuration updates to the backing storage.
 	UpdateOptions func(remoteName string, options map[string]any) error
 }
 
+// registry is the global map of provider types to their respective factories.
 var registry = make(map[string]Factory)
 
+// Register registers a new Provider Factory against a specific type name.
+// This is typically called within init() functions in individual provider packages.
 func Register(typeName string, factory Factory) {
 	registry[typeName] = factory
 }
 
+// ListTypes returns a list of all registered provider types.
+// This is primarily used for interactive CLI prompts when creating a new remote.
 func ListTypes() []string {
 	var types []string
 	for t := range registry {
@@ -105,6 +120,9 @@ func NewResolver(loader *config.ConfigLoader) Resolver {
 	return resolve
 }
 
+// resolveOne implements the underlying lookup and instantiation logic for Resolver.Provider.
+// It first attempts an exact match of the given remoteName in the configuration. If that fails
+// and the name matches a prefix in the format "name:*", it attempts an implicit balance group resolution.
 func resolveOne(conf *config.Config, remoteName string, resolve Resolver) (Provider, error) {
 	rc, exactMatch := conf.Remotes[remoteName]
 
@@ -166,6 +184,8 @@ func resolveOne(conf *config.Config, remoteName string, resolve Resolver) (Provi
 	return factory(remoteName, opts, resolve)
 }
 
+// NewProvider constructs a new Provider of the given type, bypassing the config loader.
+// It is intended for testing or isolated instantiations where a full Resolver is unnecessary.
 func NewProvider(typeName string, name string, options map[string]any) (Provider, error) {
 	factory, ok := registry[typeName]
 	if !ok {


### PR DESCRIPTION
Assumptions:
- Only adding docstrings for public/exported members in `pkg/remote` satisfies the "Docs" objective constraint of ONE cohesive area per PR.
- Pre-existing lint errors outside of `pkg/remote` were not touched to adhere strictly to the Max lines: 280 constraint and the "scope discipline" of this agent.
- Go's idiomatic `//` comments are used, as per the instruction to use the standard format of the language.

Alternatives Not Chosen:
- Fixing unrelated linting issues across the codebase (abandoned due to scope explosion).
- Refactoring `registry.go`'s `resolveOne` function (abandoned as it violated "Must not change: executable logic").

How To Pivot:
- To extend documentation to another package, modify the target file in the diff and repeat.
- To use Godoc `/* */` block comments instead, run `sed -i 's/\/\/ /\/* /; s/$/ *\//' <file>` for the relevant sections.

Next Knobs:
- Review the `pkg/providers/*` implementations for similar documentation gaps.
- The `pkg/protocol` layer needs documentation on the exact LLM interaction format.

---
*PR created automatically by Jules for task [4854547654874056071](https://jules.google.com/task/4854547654874056071) started by @lucasew*