### PR TITLE
fix(server): set HTTP server timeouts on ListenAndServe

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -4,6 +4,7 @@ import (
 	"log/slog"
 	"net/http"
 	"net/http/pprof"
+	"time"
 
 	anthropicprotocol "github.com/lucasew/mclone/pkg/protocol/anthropic"
 	openaiprotocol "github.com/lucasew/mclone/pkg/protocol/openai"
@@ -59,5 +60,15 @@ func (s *Server) Handler() http.Handler {
 }
 
 func (s *Server) ListenAndServe(addr string) error {
-	return http.ListenAndServe(addr, s.Handler())
+	// ReadHeaderTimeout bounds slowloris-style header stalls.
+	// IdleTimeout reclaims keep-alive connections left idle.
+	// WriteTimeout is left at 0: chat/responses stream via SSE and can run
+	// longer than any short global write deadline.
+	srv := &http.Server{
+		Addr:              addr,
+		Handler:           s.Handler(),
+		ReadHeaderTimeout: 10 * time.Second,
+		IdleTimeout:       120 * time.Second,
+	}
+	return srv.ListenAndServe()
 }


### PR DESCRIPTION
## Problem

`Server.ListenAndServe` called `http.ListenAndServe` with zero timeouts. That leaves the server open to slowloris-style header stalls and idle keep-alive connections that never die.

## Change

Use an explicit `http.Server` with:

- `ReadHeaderTimeout: 10s` — bound time spent reading request headers
- `IdleTimeout: 120s` — reclaim keep-alive connections left idle
- **no `WriteTimeout`** (zero) — chat and responses APIs stream over SSE; a short global write deadline would kill long streams mid-token

`ListenAndServe(addr string) error` signature is unchanged.

## Why not WriteTimeout

go-security recommends Read/Write/Idle timeouts. For this binary, WriteTimeout would break streaming (`pkg/protocol/sse.go`, Anthropic/OpenAI writers, responses SSE). ReadHeaderTimeout is the critical slowloris control; IdleTimeout covers idle keep-alives.

## Verified

- `go test ./pkg/server/...`
- `go build ./...`