### PR TITLE
fix(config): use errors.Is for missing config path

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -60,13 +61,15 @@ func (c *ConfigLoader) GetLocation() (string, error) {
 	if err == nil {
 		return c.Location, nil
 	}
-	if err == os.ErrNotExist {
-		f, err := os.Create(c.Location)
-		if err != nil {
-			return "", err
-		}
-		defer f.Close()
+	// os.Stat returns *fs.PathError wrapping ErrNotExist; == never matches.
+	if !errors.Is(err, os.ErrNotExist) {
+		return "", err
 	}
+	f, err := os.Create(c.Location)
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
 	return c.Location, nil
 }
 

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1,0 +1,61 @@
+package config
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestGetLocation_CreatesMissingFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "mclone.conf")
+
+	loader := &ConfigLoader{Location: path}
+	got, err := loader.GetLocation()
+	if err != nil {
+		t.Fatalf("GetLocation: %v", err)
+	}
+	if got != path {
+		t.Fatalf("GetLocation path = %q, want %q", got, path)
+	}
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("expected config file to be created: %v", err)
+	}
+}
+
+func TestGetLocation_ExistingFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "mclone.conf")
+	if err := os.WriteFile(path, []byte("remotes = {}"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	loader := &ConfigLoader{Location: path}
+	got, err := loader.GetLocation()
+	if err != nil {
+		t.Fatalf("GetLocation: %v", err)
+	}
+	if got != path {
+		t.Fatalf("GetLocation path = %q, want %q", got, path)
+	}
+}
+
+func TestGetLocation_SurfacesNonNotExistStatError(t *testing.T) {
+	dir := t.TempDir()
+	// Stat fails with ENOTDIR when a path component is a file, not a directory.
+	blocker := filepath.Join(dir, "not-a-dir")
+	if err := os.WriteFile(blocker, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(blocker, "mclone.conf")
+
+	loader := &ConfigLoader{Location: path}
+	_, err := loader.GetLocation()
+	if err == nil {
+		t.Fatal("GetLocation: expected error for non-NotExist Stat failure")
+	}
+	if errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("GetLocation: unexpected NotExist error: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

`GetLocation` compared `err == os.ErrNotExist` after `os.Stat`. Stat returns a `*fs.PathError` that wraps `ErrNotExist`, so the equality check never matched: the create-empty-file path never ran, and other Stat failures still returned the path as success.

- Detect missing files with `errors.Is(err, os.ErrNotExist)`
- Return non-`NotExist` Stat errors to the caller
- Add unit tests for create-on-missing, existing file, and non-NotExist Stat failure

## Test plan

- [x] `go test ./pkg/config/... -v`
- [ ] CI green on this PR