### PR TITLE
fix(ollama): check List request errors and HTTP status

### DIFF
--- a/pkg/providers/ollama/ollama.go
+++ b/pkg/providers/ollama/ollama.go
@@ -30,12 +30,19 @@ func (p *OllamaProvider) Name() string { return "ollama" }
 func (p *OllamaProvider) List(ctx context.Context) ([]remote.Model, error) {
 	client := &http.Client{Timeout: 5 * time.Second}
 	url := fmt.Sprintf("%s/api/tags", p.BaseURL)
-	req, _ := http.NewRequestWithContext(ctx, "GET", url, nil)
+	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("ollama list request: %w", err)
+	}
 	resp, err := client.Do(req)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("ollama list: %w", err)
 	}
 	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("ollama list: unexpected status %d", resp.StatusCode)
+	}
 
 	var tags struct {
 		Models []struct {
@@ -44,7 +51,7 @@ func (p *OllamaProvider) List(ctx context.Context) ([]remote.Model, error) {
 		} `json:"models"`
 	}
 	if err := json.NewDecoder(resp.Body).Decode(&tags); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("ollama list decode: %w", err)
 	}
 
 	var models []remote.Model

--- a/pkg/providers/ollama/ollama_test.go
+++ b/pkg/providers/ollama/ollama_test.go
@@ -1,0 +1,95 @@
+package ollama
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestListSuccess(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/tags" {
+			t.Errorf("path = %q, want /api/tags", r.URL.Path)
+		}
+		if r.Method != http.MethodGet {
+			t.Errorf("method = %q, want GET", r.Method)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"models":[{"name":"llama3","size":123},{"name":"mistral","size":456}]}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	p := &OllamaProvider{BaseURL: srv.URL}
+	models, err := p.List(context.Background())
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(models) != 2 {
+		t.Fatalf("len(models) = %d, want 2", len(models))
+	}
+	if models[0].Name != "llama3" || models[0].Slug != "llama3" {
+		t.Errorf("models[0] = %+v, want name/slug llama3", models[0])
+	}
+	if models[1].Name != "mistral" {
+		t.Errorf("models[1].Name = %q, want mistral", models[1].Name)
+	}
+}
+
+func TestListNonOKStatus(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`internal error`))
+	}))
+	t.Cleanup(srv.Close)
+
+	p := &OllamaProvider{BaseURL: srv.URL}
+	_, err := p.List(context.Background())
+	if err == nil {
+		t.Fatal("List: want error for non-200 status, got nil")
+	}
+	if !strings.Contains(err.Error(), "500") {
+		t.Errorf("error %q does not include status 500", err)
+	}
+	if strings.Contains(err.Error(), "invalid character") {
+		t.Errorf("error should not be a JSON decode failure, got %q", err)
+	}
+}
+
+func TestListInvalidJSON(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`not-json`))
+	}))
+	t.Cleanup(srv.Close)
+
+	p := &OllamaProvider{BaseURL: srv.URL}
+	_, err := p.List(context.Background())
+	if err == nil {
+		t.Fatal("List: want decode error, got nil")
+	}
+	if !strings.Contains(err.Error(), "decode") {
+		t.Errorf("error %q should mention decode", err)
+	}
+}
+
+func TestListRequestError(t *testing.T) {
+	t.Parallel()
+
+	// Control characters in the URL make NewRequestWithContext fail.
+	p := &OllamaProvider{BaseURL: "http://example.com/\x00"}
+	_, err := p.List(context.Background())
+	if err == nil {
+		t.Fatal("List: want request construction error, got nil")
+	}
+	if !strings.Contains(err.Error(), "request") {
+		t.Errorf("error %q should mention request construction", err)
+	}
+}


### PR DESCRIPTION
## Problem

`OllamaProvider.List` ignored the error from `http.NewRequestWithContext` (`req, _ := ...`) and never checked `resp.StatusCode` before JSON-decoding the body. A non-200 response (HTML error page, plain text, etc.) became a cryptic decode error instead of a clear status failure.

## Change

- Propagate and wrap `NewRequestWithContext` errors
- After `Do`, require HTTP 200; return a wrapped error that includes the status code
- Wrap transport and decode errors with short context (`ollama list: …`)
- Keep the existing 5s client timeout

## Tests

`httptest`-based unit tests cover success, non-200 status (asserts no JSON decode path), invalid JSON, and request construction failure.

## Verified

```
go test ./pkg/providers/ollama/... -count=1
go build ./...
```