### PR TITLE
fix(openai): List with bounded HTTP client and status check

### DIFF
--- a/pkg/providers/openai/openai.go
+++ b/pkg/providers/openai/openai.go
@@ -3,10 +3,13 @@ package openai
 import (
 	"context"
 	"fmt"
-	json "github.com/goccy/go-json"
+	"io"
 	"log/slog"
 	"net/http"
 	"strings"
+	"time"
+
+	json "github.com/goccy/go-json"
 
 	"github.com/lucasew/mclone/pkg/message"
 	"github.com/lucasew/mclone/pkg/monitor"
@@ -16,6 +19,10 @@ import (
 	"github.com/openai/openai-go/option"
 	"github.com/openai/openai-go/shared"
 )
+
+// listHTTPClient bounds List so a hung /models endpoint cannot block forever.
+// http.DefaultClient has no Timeout.
+var listHTTPClient = &http.Client{Timeout: 30 * time.Second}
 
 type OpenAIProvider struct {
 	BaseURL string
@@ -37,11 +44,20 @@ func (p *OpenAIProvider) List(ctx context.Context) ([]remote.Model, error) {
 	}
 	req.Header.Set("Authorization", "Bearer "+p.APIKey)
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := listHTTPClient.Do(req)
 	if err != nil {
 		return nil, err
 	}
 	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
+		msg := strings.TrimSpace(string(body))
+		if msg != "" {
+			return nil, fmt.Errorf("openai list models: status %d: %s", resp.StatusCode, msg)
+		}
+		return nil, fmt.Errorf("openai list models: status %d", resp.StatusCode)
+	}
 
 	var result struct {
 		Data []struct {

--- a/pkg/providers/openai/openai_test.go
+++ b/pkg/providers/openai/openai_test.go
@@ -1,7 +1,11 @@
 package openai
 
 import (
+	"context"
 	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
 )
 
@@ -54,5 +58,60 @@ func TestShouldIgnoreStreamError(t *testing.T) {
 				t.Fatalf("shouldIgnoreStreamError(%v, %v, %v) = %v, want %v", tt.err, tt.sawContent, tt.sawToolCall, got, tt.want)
 			}
 		})
+	}
+}
+
+func TestListSuccess(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/models" {
+			t.Errorf("path = %q, want /models", r.URL.Path)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer test-key" {
+			t.Errorf("Authorization = %q, want Bearer test-key", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":[{"id":"gpt-4o","owned_by":"openai"},{"id":"o1-mini","owned_by":""}]}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	p := &OpenAIProvider{BaseURL: srv.URL, APIKey: "test-key"}
+	models, err := p.List(context.Background())
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(models) != 2 {
+		t.Fatalf("len(models) = %d, want 2", len(models))
+	}
+	if models[0].Name != "gpt-4o" || models[0].Slug != "gpt-4o" {
+		t.Errorf("models[0] = %+v, want Name/Slug gpt-4o", models[0])
+	}
+	if len(models[0].OwnedBy) != 1 || models[0].OwnedBy[0] != "openai" {
+		t.Errorf("models[0].OwnedBy = %v, want [openai]", models[0].OwnedBy)
+	}
+	if models[1].OwnedBy != nil {
+		t.Errorf("models[1].OwnedBy = %v, want nil", models[1].OwnedBy)
+	}
+}
+
+func TestListNon2xx(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, `{"error":{"message":"invalid_api_key"}}`, http.StatusUnauthorized)
+	}))
+	t.Cleanup(srv.Close)
+
+	p := &OpenAIProvider{BaseURL: srv.URL, APIKey: "bad"}
+	_, err := p.List(context.Background())
+	if err == nil {
+		t.Fatal("List: want error for 401")
+	}
+	if !strings.Contains(err.Error(), "status 401") {
+		t.Errorf("error = %q, want status 401", err)
+	}
+	if !strings.Contains(err.Error(), "invalid_api_key") {
+		t.Errorf("error = %q, want body snippet", err)
 	}
 }


### PR DESCRIPTION
## Problem

`OpenAIProvider.List` used `http.DefaultClient` (no `Timeout`) and decoded the response without checking `StatusCode`. A hung `/models` endpoint can block forever; API error bodies show up as opaque JSON decode failures.

## Change

- Use a package-level `http.Client` with a 30s timeout for List only
- Reject non-2xx responses with a clear status error (optional short body snippet)
- httptest coverage for success and 401 paths
- Chat/SDK paths untouched

## Verify

- `go test ./pkg/providers/openai/...`
- `go build ./...`